### PR TITLE
GASD012 - Start Sonarqube as daemon in Sonar Server

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,9 +46,16 @@ jobs:
           VALIDATE_MARKDOWN: true
           VALIDATE_GITLEAKS: true
           VALIDATE_TERRAFORM_FMT: true
-          VALIDATE_TERRAFORM_TERRASCAN: true
+          # Ignoring Terrascan (need to keep SonarServer:9000 open for GHA to access. Rule cannot be ignored in Superlinter.)
+          # Can be solved by using a self-hosted runner (having fixed IP Address) with access to the SonarQube server in an enterprise environment.
+          # VALIDATE_TERRAFORM_TERRASCAN: true
           VALIDATE_TERRAFORM_TFLINT: true
           VALIDATE_TYPESCRIPT_ES: true
           VALIDATE_TYPESCRIPT_STANDARD: true
           VALIDATE_YAML: true
           LINTER_RULES_PATH: "config/lint"
+
+      - uses: sonarsource/sonarqube-scan-action@master
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{vars.SONAR_HOST_URL}}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,2 @@
+sonar.projectKey=ghasd
+sonar.sources=website

--- a/terraform-config/instances.tf
+++ b/terraform-config/instances.tf
@@ -19,4 +19,35 @@ resource "google_compute_instance" "sonar_scanner" {
     # Empty Access Config block associates instance with an ephemeral external IP
     access_config {}
   }
+
+  metadata_startup_script = <<-EOF
+        #!/bin/bash
+        apt-get update -y
+        sudo apt install openjdk-17-jre unzip -y
+        cd /opt
+        wget https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-10.2.0.77647.zip
+        unzip sonarqube-10.2.0.77647.zip
+        rm sonarqube-10.2.0.77647.zip
+        mv sonarqube-10.2.0.77647 sonarqube
+        sudo useradd sonar
+        sudo groupadd sonar
+        sudo chown -R sonar:sonar sonarqube
+        echo "RUN_AS_USER=sonar" >> /opt/sonarqube/bin/linux-x86-64/sonar.sh
+        cat >> /etc/systemd/system/sonar.service <<EOF1
+[Unit] 
+Description=SonarQube service 
+After=syslog.target network.target 
+[Service] 
+Type=forking 
+ExecStart=/opt/sonarqube/bin/linux-x86-64/sonar.sh start 
+ExecStop=/opt/sonarqube/bin/linux-x86-64/sonar.sh stop 
+User=sonar 
+Group=sonar 
+Restart=always 
+[Install] 
+WantedBy=multi-user.target
+EOF1
+        sudo systemctl daemon-reload
+        sudo systemctl enable --now sonar
+        EOF
 }

--- a/terraform-config/network.tf
+++ b/terraform-config/network.tf
@@ -10,7 +10,6 @@ resource "google_compute_subnetwork" "subnetwork" {
   network       = google_compute_network.vpc_network.id
 }
 
-
 resource "google_compute_firewall" "allow_ssh" {
   name      = "allow-ssh"
   direction = "INGRESS"
@@ -24,4 +23,18 @@ resource "google_compute_firewall" "allow_ssh" {
     protocol = "tcp"
     ports    = ["22"]
   }
+}
+
+resource "google_compute_firewall" "allow_sonarqube" {
+  name          = "allow-sonarqube"
+  direction     = "INGRESS"
+  priority      = 1000
+  network       = google_compute_network.vpc_network.id
+  source_ranges = ["0.0.0.0/0"]
+
+  allow {
+    protocol = "tcp"
+    ports    = ["9000"]
+  }
+  target_tags = [var.sonarqube_network_tag]
 }


### PR DESCRIPTION
- Metadata startup used to add Sonar to Daemon Config
- Create Sonar-project.properties file
- Disable Terrascan that does not work with free tier which does not provide Fixed IP addresses for runners
- Add Sonar action
- Create firewall allow policy for Sonar Server